### PR TITLE
Update Wagtail installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,21 @@ class Rendition(AbstractRendition):
         unique_together = (("image", "filter_spec", "focal_point_key"),)
 ```
 
+Add kontrasto to your installed apps. In your settings module:
+
+```python
+INSTALLED_APPS = [
+    # ...
+    # other apps
+    "kontrasto",
+]
+```
+
 Then, in templates:
 
 ```html
+{% load kontrasto_tags %}
+
 {% wcag_2_contrast_light_or_dark page.test_image "#ffffff" "#000000" as result
 %} {% wcag_3_contrast_light_or_dark page.test_image "#ffffff" "#000000" as
 result_3 %}


### PR DESCRIPTION
This adds mention of importing the template tag library, and adding kontrasto to INSTALLED_APPS.

Note also that the current version in the repository is not the latest on PyPI: the `wgac_3_contrast_light_or_dark` template tag is not available in 0.1.0 on PyPI. Maybe a version tag and a release in Git would help to iron out that confusion.
